### PR TITLE
Add environment variables for RabbitMQ service in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
     ports:
       - "15672:15672"
       - "5672:5672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=password
     networks:
       - shared_network
 


### PR DESCRIPTION
This pull request introduces an update to the RabbitMQ service configuration in the `docker-compose.yml` file. The most important change involves adding environment variables for setting default credentials.

Configuration updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R28-R30): Added `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` environment variables to configure default RabbitMQ credentials.